### PR TITLE
Fix: ServiceDetailsToBeRequested to be a Integer instead of a short

### DIFF
--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/session/V2GCommunicationSessionEVCC.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/session/V2GCommunicationSessionEVCC.java
@@ -95,7 +95,7 @@ public class V2GCommunicationSessionEVCC extends V2GCommunicationSession impleme
 	private ChargingProfileType chargingProfile;
 	private ServiceListType offeredServices;
 	private SelectedServiceListType selectedServices; 
-	private ArrayList<Short> serviceDetailsToBeRequested;
+	private ArrayList<Integer> serviceDetailsToBeRequested;
 	private EnergyTransferModeType requestedEnergyTransferMode;
 	private long evseScheduleReceived; // The timestamp of receiving the SAScheduleList from the EVSE, is used as a reference
 	private List<AppProtocolType> supportedAppProtocols;
@@ -436,9 +436,9 @@ public class V2GCommunicationSessionEVCC extends V2GCommunicationSession impleme
 	}
 
 
-	public ArrayList<Short> getServiceDetailsToBeRequested() {
+	public ArrayList<Integer> getServiceDetailsToBeRequested() {
 		if (serviceDetailsToBeRequested == null) {
-			serviceDetailsToBeRequested = new ArrayList<Short>();
+			serviceDetailsToBeRequested = new ArrayList<Integer>();
 		}
 		
 		return serviceDetailsToBeRequested;
@@ -446,7 +446,7 @@ public class V2GCommunicationSessionEVCC extends V2GCommunicationSession impleme
 
 
 	public void setServiceDetailsToBeRequested(
-			ArrayList<Short> serviceDetailsToBeRequested) {
+			ArrayList<Integer> serviceDetailsToBeRequested) {
 		this.serviceDetailsToBeRequested = serviceDetailsToBeRequested;
 	}
 

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/ClientState.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/ClientState.java
@@ -230,10 +230,10 @@ public abstract class ClientState extends State {
 	 */
 	protected ServiceDetailReqType getServiceDetailReq() {
 		if (getCommSessionContext().getServiceDetailsToBeRequested().size() > 0) {
-			ListIterator<Short> listIterator = getCommSessionContext().getServiceDetailsToBeRequested().listIterator();
+			ListIterator<Integer> listIterator = getCommSessionContext().getServiceDetailsToBeRequested().listIterator();
 			
 			ServiceDetailReqType serviceDetailReq = new ServiceDetailReqType();
-			serviceDetailReq.setServiceID((short) listIterator.next());
+			serviceDetailReq.setServiceID(listIterator.next());
 			
 			listIterator.remove();
 			

--- a/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/WaitForServiceDiscoveryRes.java
+++ b/RISE-V2G-EVCC/src/main/java/com/v2gclarity/risev2g/evcc/states/WaitForServiceDiscoveryRes.java
@@ -176,7 +176,7 @@ public class WaitForServiceDiscoveryRes extends ClientState {
 		 * so don't send a ServiceDetailReq for a ChargeService
 		 */
 		if (serviceID != 1)
-			getCommSessionContext().getServiceDetailsToBeRequested().add((short) serviceID);
+			getCommSessionContext().getServiceDetailsToBeRequested().add(serviceID);
 	}
 	
 	


### PR DESCRIPTION
serviceIDtype is a xs:unsignedShort, that doesn't fit in a Java Short, it does in a Integer (but the range is to big) 

If you currently have a VAS with serviceID > 32,767 you end up with a negative number in the XML/EXI data. Based on the ISO specification 0-60000 is reserved for the ISO standard, and >= 60001 can be used for implementation specific use, as a result you encounter this issue.