### PR TITLE
dependency upgrades for java 11

### DIFF
--- a/RISE-V2G-Shared/pom.xml
+++ b/RISE-V2G-Shared/pom.xml
@@ -37,12 +37,12 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.13.3</version>
+		    <version>2.17.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.17.0</version>
+		    <version>2.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.openexi</groupId>
@@ -53,6 +53,21 @@
 			<groupId>net.sourceforge.openexi</groupId>
 			<artifactId>nagasena-rta</artifactId>
 			<version>0000.0002.0052.0</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.5</version>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
Dependency upgrades for java 11.

Combines #57 #63 

including log4j upgrade to 2.17.1